### PR TITLE
 Display link indicating a truncated summary

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -14,6 +14,9 @@
                 <p>
                 {{ .Summary }}
                 </p>
+                {{ if .Truncated }}
+                <p><a href="{{ .RelPermalink }}">(read more…)</a></p>
+                {{ end }}
             </div>
             <div class="post-footer">
             <time>{{ .Date.Format "January 2, 2006" }}</time>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,12 @@
                     {{ .Title }}
                 </a>
             </h2>
-            <div><p>{{ .Summary }}</p></div>
+            <div>
+                <p>{{ .Summary }}</p>
+                {{ if .Truncated }}
+                <p><a href="{{ .RelPermalink }}">(read more…)</a></p>
+                {{ end }}
+            </div>
             <div class="post-footer">
             <time>{{ .Date.Format "January 2, 2006" }}</time>
 


### PR DESCRIPTION
Adds link with text `(read more...)` to post summaries on the index and taxonomy pages.

This helps show a link asking the user to continue when the summary gets truncated on the listing page.
Without it, the summary truncation appears arbitrary and carries no indication of further content.

Link will show up right after an explicit <!--more--> summary divider inside a post, or at the default/configured summary truncation length when a post exceeds it.